### PR TITLE
make the font monospace again

### DIFF
--- a/src/BrutalistMono-Bold.sfd
+++ b/src/BrutalistMono-Bold.sfd
@@ -7878,7 +7878,7 @@ EndChar
 
 StartChar: r
 Encoding: 114 114 83
-Width: 1239
+Width: 1233
 Flags: W
 AnchorPoint: "below" 571 0 basechar 0
 AnchorPoint: "above" 571 1120 basechar 0
@@ -16346,7 +16346,7 @@ EndChar
 
 StartChar: racute
 Encoding: 341 341 277
-Width: 1239
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -16367,7 +16367,7 @@ EndChar
 
 StartChar: rcommaaccent
 Encoding: 343 343 279
-Width: 1239
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -16388,7 +16388,7 @@ EndChar
 
 StartChar: rcaron
 Encoding: 345 345 281
-Width: 1239
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -20152,7 +20152,7 @@ EndChar
 
 StartChar: uni0211
 Encoding: 529 529 457
-Width: 1239
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -20172,7 +20172,7 @@ EndChar
 
 StartChar: uni0213
 Encoding: 531 531 459
-Width: 1239
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -50462,7 +50462,7 @@ EndChar
 
 StartChar: uni1E59
 Encoding: 7769 7769 1613
-Width: 1239
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -50482,7 +50482,7 @@ EndChar
 
 StartChar: uni1E5B
 Encoding: 7771 7771 1615
-Width: 1239
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -50502,7 +50502,7 @@ EndChar
 
 StartChar: uni1E5D
 Encoding: 7773 7773 1617
-Width: 1239
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -50522,7 +50522,7 @@ EndChar
 
 StartChar: uni1E5F
 Encoding: 7775 7775 1619
-Width: 1239
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore

--- a/src/BrutalistMono-BoldOblique.sfd
+++ b/src/BrutalistMono-BoldOblique.sfd
@@ -11353,7 +11353,7 @@ EndChar
 
 StartChar: asciitilde
 Encoding: 126 126 95
-Width: 1236
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore

--- a/src/BrutalistMono.sfd
+++ b/src/BrutalistMono.sfd
@@ -6081,7 +6081,7 @@ EndChar
 
 StartChar: S
 Encoding: 83 83 52
-Width: 1232
+Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
@@ -18028,7 +18028,7 @@ EndChar
 
 StartChar: Sacute
 Encoding: 346 346 282
-Width: 1232
+Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
@@ -18052,7 +18052,7 @@ EndChar
 
 StartChar: Scircumflex
 Encoding: 348 348 284
-Width: 1232
+Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
@@ -18075,7 +18075,7 @@ EndChar
 
 StartChar: Scedilla
 Encoding: 350 350 286
-Width: 1232
+Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
@@ -18099,7 +18099,7 @@ EndChar
 
 StartChar: Scaron
 Encoding: 352 352 288
-Width: 1232
+Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
@@ -22050,7 +22050,7 @@ EndChar
 
 StartChar: Scommaaccent
 Encoding: 536 536 464
-Width: 1232
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -33536,7 +33536,7 @@ EndChar
 
 StartChar: uni0405
 Encoding: 1029 1029 843
-Width: 1232
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -52839,7 +52839,7 @@ EndChar
 
 StartChar: uni1E60
 Encoding: 7776 7776 1620
-Width: 1232
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -52858,7 +52858,7 @@ EndChar
 
 StartChar: uni1E62
 Encoding: 7778 7778 1622
-Width: 1232
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -52878,7 +52878,7 @@ EndChar
 
 StartChar: uni1E68
 Encoding: 7784 7784 1624
-Width: 1232
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore
@@ -104252,7 +104252,7 @@ EndChar
 
 StartChar: u1D682
 Encoding: 120450 120450 3682
-Width: 1232
+Width: 1233
 Flags: W
 LayerCount: 2
 Fore


### PR DESCRIPTION
this makes the font recognized as a fixed width font by macOS.

It's a version of this bug (https://github.com/adobe-fonts/source-han-mono/issues/3), that prevents the font from showing up properly in Terminal.app.